### PR TITLE
Add override function for generateProofOfWork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "banotils",
-  "version": "0.1.7",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.7",
+      "name": "banotils",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "blakejs": "^1.1.1",


### PR DESCRIPTION
This is because cheap VPS aren't powerful enough to handle generateProofOfWork without crashing. This function lets you override the function with for example a boom-pow or a similar service implementation to fix that issue.